### PR TITLE
Fix const-correctness of filename arguments.

### DIFF
--- a/include/olewriter.h
+++ b/include/olewriter.h
@@ -25,7 +25,7 @@
 #include "io_handler.h"
 
 struct owctx {
-  char *olefilename;
+  const char *olefilename;
   struct xl_io_handler io_handler;
   void* io_handle;
   int fileclosed;
@@ -39,8 +39,8 @@ struct owctx {
   int block_count;
 };
 
-struct owctx * ow_new(char *filename);
-struct owctx * ow_new_ex(struct xl_io_handler io_handler, char *filename);
+struct owctx * ow_new(const char *filename);
+struct owctx * ow_new_ex(struct xl_io_handler io_handler, const char *filename);
 void ow_destroy(struct owctx *ow);
 int ow_set_size(struct owctx *ow, int biffsize);
 void ow_write_header(struct owctx *ow);

--- a/include/workbook.h
+++ b/include/workbook.h
@@ -51,8 +51,8 @@ struct wbookctx {
   struct xl_format **formats;
 };
 
-struct wbookctx *wbook_new(char *filename, int store_in_memory);
-struct wbookctx *wbook_new_ex(struct xl_io_handler io_handler, char *filename, int store_in_memory);
+struct wbookctx *wbook_new(const char *filename, int store_in_memory);
+struct wbookctx *wbook_new_ex(struct xl_io_handler io_handler, const char *filename, int store_in_memory);
 void wbook_close(struct wbookctx *wb);
 void wbook_destroy(struct wbookctx *wb);
 struct wsheetctx *wbook_addworksheet(struct wbookctx *wbook, char *sname);

--- a/src/olewriter.c
+++ b/src/olewriter.c
@@ -24,18 +24,18 @@
 #include "stream.h"
 #include "io_handler.h"
 
-int ow_init(struct owctx *ow, struct xl_io_handler io_handler, char *filename);
+int ow_init(struct owctx *ow, struct xl_io_handler io_handler, const char *filename);
 void ow_write_pps(struct owctx *ow, char *name, int pps_type, int pps_dir, int pps_start, int pps_size);
 void ow_write_property_storage(struct owctx *ow);
 void ow_write_padding(struct owctx *ow);
 void ow_write_big_block_depot(struct owctx *ow);
 
-struct owctx * ow_new(char *filename)
+struct owctx * ow_new(const char *filename)
 {
   return ow_new_ex(xl_file_handler,filename);
 }
 
-struct owctx * ow_new_ex(struct xl_io_handler io_handler, char *filename)
+struct owctx * ow_new_ex(struct xl_io_handler io_handler, const char *filename)
 {
   struct owctx *ow;
 
@@ -56,7 +56,7 @@ void ow_destroy(struct owctx *ow)
   free(ow);
 }
 
-int ow_init(struct owctx *ow, struct xl_io_handler io_handler, char *filename)
+int ow_init(struct owctx *ow, struct xl_io_handler io_handler, const char *filename)
 {
   void *fp;
 

--- a/src/workbook.c
+++ b/src/workbook.c
@@ -35,12 +35,12 @@ static void wbook_store_num_format(struct wbookctx *wbook, char *format, int ind
 static void wbook_store_codepage(struct wbookctx *wbook);
 void wbook_store_all_num_formats(struct wbookctx *wbook);
 
-struct wbookctx *wbook_new(char *filename, int store_in_memory)
+struct wbookctx *wbook_new(const char *filename, int store_in_memory)
 {
 	return wbook_new_ex(xl_file_handler, filename, store_in_memory);
 }
 
-struct wbookctx *wbook_new_ex(struct xl_io_handler io_handler, char *filename, int store_in_memory)
+struct wbookctx *wbook_new_ex(struct xl_io_handler io_handler, const char *filename, int store_in_memory)
 {
   struct wbookctx *wbook;
 


### PR DESCRIPTION
Other similar fixes ought to be applied to other `char*` arguments of various functions, but this is a start, and doesn't require changing any actual code.